### PR TITLE
Fix case when ILIKE encounters a value with spaces in it

### DIFF
--- a/src/utils/db.utils.ts
+++ b/src/utils/db.utils.ts
@@ -66,7 +66,16 @@ export function getWhere<T extends typeof BaseModel>(model: T, filterString?: st
         operator = `${operator} ${value}`;
         value = null;
       }
+      if (operator.startsWith('ILIKE') || operator.startsWith('LIKE')) {
+        const operatorSplit = operator.split(' ');
 
+        if (operatorSplit.length > 1) {
+          // Handle cases where {value} is a text that includes a space
+          // ie "ILIKE Ash Ketchup"
+          operator = operatorSplit[0];
+          value = operatorSplit.slice(1).join(' ');
+        }
+      }
       // Handle JSON path
       if (field.includes('.')) {
         jsonPath = field.split('.');


### PR DESCRIPTION
### Context:

We were getting an error when we were attempting to do an `ILIKE ash ketch` where the value half of the string has a space in it.

![Screenshot 2024-04-17 at 5 38 04 PM](https://github.com/cloudflare-extension/unconventional/assets/5092263/898fe218-8f94-45cc-bdf2-6e9ec6fc5fab)

This PR helps handle that case.