### PR TITLE
Allow WHERE operator to Support Spaces in Condition Value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unconventional",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unconventional",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20231121.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unconventional",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A complete server built on Cloudflare Pages Functions",
   "keywords": [
     "cloudflare",


### PR DESCRIPTION
The WHERE operator would not be able to support spaces in the condition value - for example: `name LIKE 'John Smith'`

This change refactors how the `getWhere` function fetches each `filter`'s `field`, `operator`, and `value` so that it supports the above.

At a high level (through @DeanMauro's suggestion), this change does the following:
1. Find the first instance of a single quote.
2. Loop through the `SqlWhereOperators` and find the first instance of it surrounded by spaces but also before the first single quote (if one exists) (to ensure we're not matching a value). If multiple `SqlWhereOperators` match, use the longest.
3. Save this as the operator. Treat everything before as the field and everything after as the value.

I tested the following queries (eventually, these should be in unit tests) manually:

```
Eq = "=",
  - firstName = Maxwell
  - firstName = 'Maxwell Test'

Neq = "<>",
  - firstName <> Maxwell
  - firstName <> 'Maxwell Test'

Gt = ">",
  - id > 5

Gte = ">=",
   - id >= 5

Lt = "<",
   - id < 5

Lte = "<=",
  - id <= 5

Like = "LIKE",
  - firstName LIKE Maxwell
  - firstName LIKE '%Maxwell Test%'

ILike = "ILIKE",
  - firstName ILIKE MaxWELL
  - firstName ILIKE '%MaxWELL%'

NotLike = "NOT LIKE",
  - firstName NOT LIKE Maxwell
  - firstName NOT LIKE '%Maxwell%'

In = "IN",
  - firstName IN ('Maxwell', 'Dean')
  - id IN (1, 2, 3)

NotIn = "NOT IN",
  - firstName NOT IN ('Maxwell', 'Dean')
  - id NOT IN (1, 2, 3)

IsNull = "IS NULL",
  - manager IS NULL

IsNotNull = "IS NOT NULL",
  - manager IS NOT NULL

BitwiseAnd = "&"
  - id & 4
```

**Example Outputs with logging:**
![image](https://github.com/cloudflare-extension/unconventional/assets/60411452/17181a97-bd3c-4024-8b0d-d0540360c911)

![image](https://github.com/cloudflare-extension/unconventional/assets/60411452/c9fe021e-1f1a-419a-b5cd-54aed21ea18a)

![image](https://github.com/cloudflare-extension/unconventional/assets/60411452/e29fca10-6e25-459d-9c26-ed0e011e6b68)
