### PR TITLE
Fix waitUntil by binding to its executionCtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#### 2.0.1 (2025-12-23)
+
+##### Bug Fixes
+
+*  Fix "Illegal invocation" error when using `context.waitUntil` in ResponseProcessor hooks by properly binding the method to its execution context. ([72c3452](https://github.com/cloudflare-extension/unconventional/commit/72c3452bd1415d69d3316f99e282c47b6db8a068))
+
+
 ## 2.0.0 (2025-12-04)
 
 ##### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unconventional",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unconventional",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20231121.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unconventional",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A complete server built on Cloudflare Workers/Pages",
   "keywords": [
     "cloudflare",

--- a/src/core/abstractbase.controller.ts
+++ b/src/core/abstractbase.controller.ts
@@ -318,7 +318,7 @@ export abstract class AbstractBaseController<M extends typeof BaseModel, E exten
 
     return {
       headers: ctx.req.raw.headers,
-      waitUntil: ctx.executionCtx.waitUntil,
+      waitUntil: ctx.executionCtx?.waitUntil.bind(ctx.executionCtx),
       body: body,
       params: ctx.req.param(),
       queries: ctx.req.query(),


### PR DESCRIPTION
Fix "Illegal invocation" error when using `context.waitUntil` in ResponseProcessor hooks by properly binding the method to its execution context.